### PR TITLE
Increase JavaScript codebase test timeout

### DIFF
--- a/test.js
+++ b/test.js
@@ -141,5 +141,7 @@ describe('shared-git-hooks', () => {
 })
 
 describe('JavaScript codebase', function () {
+  this.timeout(10000)
+
   it('conforms to javascript standard style (http://standardjs.com)', require('mocha-standard'))
 })


### PR DESCRIPTION
Sometimes JavaScript codebase fails due to timeout issue. Increase timeout
as pointed [1] to fix that issue.

[1] https://github.com/rstacruz/mocha-standard#timeouts

Signed-off-by: Marcin Niesluchowski <m.niesluchow@samsung.com>