### PR TITLE
fixed hook template for paths with spaces

### DIFF
--- a/hook.sh.tpl
+++ b/hook.sh.tpl
@@ -2,11 +2,11 @@
 
 FILENAME="$(basename "$0")"
 GIT_HOOKS_DIR="${GIT_HOOKS_DIR:=$(pwd)/hooks}"
-GIT_HOOK_PATH="$GIT_HOOKS_DIR/$(ls $GIT_HOOKS_DIR | grep $FILENAME)"
+GIT_HOOK_PATH="$GIT_HOOKS_DIR"/$(ls "$GIT_HOOKS_DIR" | grep "$FILENAME")
 PATH="{{PATH}}"
 
 if [ -f "$GIT_HOOK_PATH" ]; then
   echo "> $GIT_HOOK_PATH exists, running"
   echo ""
-  $GIT_HOOK_PATH $@
+  "$GIT_HOOK_PATH" $@
 fi


### PR DESCRIPTION
Fixes errors if the repo you're using this from has spaces anywhere along its name like:
`~/workspaces/some folder name with spaces/myrepo`